### PR TITLE
Bug 1507321 - fixed binding parameters to work with mediawiki.

### DIFF
--- a/roles/rhscl-mysql-apb-openshift/tasks/main.yml
+++ b/roles/rhscl-mysql-apb-openshift/tasks/main.yml
@@ -25,9 +25,10 @@
 - name: encode bind credentials
   asb_encode_binding:
     fields:
-      MYSQL_HOST: "{{ mysql_service.service.spec.cluster_ip }}"
-      MYSQL_PORT: "3306"
-      MYSQL_USER: "{{ mysql_user }}"
-      MYSQL_PASSWORD: "{{ mysql_password }}"
-      MYSQL_DATABASE: "{{ mysql_database }}"
+      DB_TYPE: "mysql"
+      DB_HOST: "{{ mysql_service.service.spec.cluster_ip }}"
+      DB_PORT: "3306"
+      DB_USER: "{{ mysql_user }}"
+      DB_PASSWORD: "{{ mysql_password }}"
+      DB_NAME: "{{ mysql_database }}"
   when: state == 'present'


### PR DESCRIPTION
Using the generic fields also allows applications to switch
between different databases.