### PR TITLE
Bug 1508278 - Use include_tasks instead of include

### DIFF
--- a/roles/rhscl-mysql-apb-openshift/tasks/main.yml
+++ b/roles/rhscl-mysql-apb-openshift/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: dev.yml
+- include_tasks: dev.yml
   when: _apb_plan_id == "dev"
 
-- include: prod.yml
+- include_tasks: prod.yml
   when: _apb_plan_id == "prod"
 
 - name: Set {{ service_name }} service state to {{ state }}


### PR DESCRIPTION
include is deprecated and throws a warning